### PR TITLE
docs(devlog): add thought process and follow-ups

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,0 +1,1 @@
+# DEVLOG\n\n- Rationale: reliability first\n- Decisions: selectors, data handling\n- Follow-ups: safe perf, tests, ultra (exp)\n


### PR DESCRIPTION
What
- Add DEVLOG.md documenting decisions, trade-offs, and next steps.

Why
- Make the thought process explicit before the code review.

How tested
- Docs only.

Notes
- No runtime changes.
