### PR TITLE
test(utils): header normalization & dtype=str

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,0 +1,1 @@
+# DEVLOG\n\n- Rationale: reliability first\n- Decisions: selectors, data handling\n- Follow-ups: safe perf, tests, ultra (exp)\n

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The bot reads data from a spreadsheet (Excel or CSV) and fills 10 rounds of form
 ### 1) Clone & create environment
 ```bash
 git clone https://github.com/jn-ww/rpa_challenge.git
-cd rpa-challenge
+cd rpa_challenge
 
 # virtual environment
 python -m venv .venv
@@ -71,7 +71,7 @@ python -m src.main --file data/challenge.xlsx --headless --perf
 ```
 
 ### 4) Docker (optional)
-Run the challenge headless inside a container. Artifacts are saved to ./screenshots/
+Run the challenge headless inside a container. Docker image is named rpa-challenge (hyphen). The repository directory is rpa_challenge (underscore). Artifacts are saved to ./screenshots/
 ```bash
 # Build the image
 docker build -t rpa-challenge .
@@ -111,7 +111,7 @@ Artifacts: after the run, check screenshots/result.png and screenshots/run_summa
 
 ## Project structure
 ```
-rpa-challenge/
+rpa_challenge/
 ├── data/
 │   ├── challenge.xlsx         # exam input
 │   └── sample.csv             # sample dataset included for quick runs & CI

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@
 playwright>=1.45,<2
 pandas>=2.2
 openpyxl>=3.1
+pytest>=8.0.0
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,57 @@
+import pytest
+import pandas as pd
+
+from src.utils import read_rows
+
+CANON = [
+    "First Name","Last Name","Company Name","Role in Company",
+    "Address","Email","Phone Number"
+]
+
+def test_header_normalization_csv(tmp_path):
+    # deliberately messy headers + an extra column that should be ignored
+    p = tmp_path / "mini.csv"
+    p.write_text(
+        " first name , LAST  NAME ,Company name,Role in company, address , Email , phone number , Extra\n"
+        "Ada,Lovelace,Analytica,Engineer,Some St,ada@ex.com,00123,noise\n"
+    )
+    rows = list(read_rows(str(p)))
+    assert len(rows) == 1
+    r = rows[0]
+
+    # canonical keys present
+    missing = [k for k in CANON if k not in r]
+    assert not missing, f"Missing canonical keys: {missing}"
+    
+    # dtype=str preserved (leading zeros)
+    assert r["Phone Number"] == "00123"
+
+    # allow extra columns; only guarantee canonical ones
+    for k in CANON:
+        assert isinstance(r[k], str)
+
+def test_empty_cells_become_empty_strings(tmp_path):
+    p = tmp_path / "empty.csv"
+    p.write_text(
+        "First Name,Last Name,Company Name,Role in Company,Address,Email,Phone Number\n"
+        "John,,Acme,,Some St,,\n"
+    )
+    r = list(read_rows(str(p)))[0]
+    # cells may be empty but must exist as keys with string values
+    for k in CANON:
+        assert k in r
+        assert isinstance(r[k], str)
+
+def test_xlsx_dtype_str(tmp_path):
+    # Skip if openpyxl not installed (CI-safe)
+    pytest.importorskip("openpyxl")
+    df = pd.DataFrame([{
+        "First Name":"John","Last Name":"Doe","Company Name":"Acme",
+        "Role in Company":"Dev","Address":"A St","Email":"j@e.com",
+        "Phone Number":"0007"
+    }])
+    x = tmp_path / "mini.xlsx"
+    df.to_excel(x, index=False)
+    rows = list(read_rows(str(x)))
+    assert rows[0]["Phone Number"] == "0007"
+


### PR DESCRIPTION
What
- Add pytest and tests for read_rows.
- Ensure canonical keys exist; dtype=str preserves leading zeros.
- Allow extra columns (ignored by automation); focus on the required contract.

Why
- Locks in the data contract for reliable browser automation.

How tested
- Local pytest; XLSX test skipped if openpyxl missing.
